### PR TITLE
Fixed Controller Bug

### DIFF
--- a/Projektarbeit III/Assets/Scripts/Player/Grappling/GrappleChecks.cs
+++ b/Projektarbeit III/Assets/Scripts/Player/Grappling/GrappleChecks.cs
@@ -3,13 +3,15 @@ using UnityEngine;
 public class GrappleChecks
 {
     private GrapplingHook grapplingHook;
+    private GrappleInputHandler grappleInputHandler;
     private Controller controller;
     private Rigidbody2D rb;
     private Enemy enemy;
 
-    public GrappleChecks(GrapplingHook grapplingHook, Controller controller, Rigidbody2D rb, Enemy enemy)
+    public GrappleChecks(GrapplingHook grapplingHook, GrappleInputHandler grappleInputHandler, Controller controller, Rigidbody2D rb, Enemy enemy)
     {
         this.grapplingHook = grapplingHook;
+        this.grappleInputHandler = grappleInputHandler;
         this.controller = controller;
         this.rb = rb;
         this.enemy = enemy;
@@ -22,7 +24,7 @@ public class GrappleChecks
             grapplingHook.StopGrapple();
         }
 
-        if (!grapplingHook.grappleAction.IsPressed())
+        if (!grappleInputHandler.grappleAction.IsPressed())
         {
             grapplingHook.StopGrapple();
         }
@@ -106,5 +108,10 @@ public class GrappleChecks
     {
         RaycastHit2D hit = Physics2D.CircleCast(grapplingHook.transform.position, grapplingHook.toleranceRadius, direction, grappleRange, grappleLayer);
         return hit;
+    }
+
+    public void SetDependencies(GrappleInputHandler grappleInputHandler)
+    {
+        this.grappleInputHandler = grappleInputHandler;
     }
 }

--- a/Projektarbeit III/Assets/Scripts/Player/Grappling/GrappleIndicator.cs
+++ b/Projektarbeit III/Assets/Scripts/Player/Grappling/GrappleIndicator.cs
@@ -34,12 +34,13 @@ public class GrappleIndicator
 
     public void UpdateGrappleIndicator(Vector2 playerPosition)
     {
+        GrappleInputHandler grappleInputHandler = grapplingHook.grappleInputHandler;
         Vector2 direction;
 
-        if (grapplingHook.isUsingController)
+        if (grappleInputHandler.isUsingController)
         {
             // Use the controller's aim input for direction
-            direction = grapplingHook.aimAction.ReadValue<Vector2>().normalized;
+            direction = grappleInputHandler.aimAction.ReadValue<Vector2>().normalized;
             if (direction != Vector2.zero)
             {
                 grapplingHook.lastControllerDirection = direction;

--- a/Projektarbeit III/Assets/Scripts/Player/Grappling/GrappleInputHandler.cs
+++ b/Projektarbeit III/Assets/Scripts/Player/Grappling/GrappleInputHandler.cs
@@ -20,17 +20,17 @@ public class GrappleInputHandler
         this.lastControllerDirection = lastControllerDirection;
 
         playerInput = controller.GetComponentInParent<PlayerInput>();
-        grappleAction = playerInput.actions["Grappling"];
-        aimAction = playerInput.actions["Aiming"];
-
-        aimAction.Enable();
-        grappleAction.Enable();
+        LoadActions();
     }
 
     public void CheckPlayerInput()
     {
-        // Check if the player is using a controller (for Aiming)
-        isUsingController = playerInput.currentControlScheme == "Gamepad";
+        if (aimAction == null && grappleAction == null)
+        {
+            LoadActions();
+        }
+
+        CheckPlayerInputMethode();
 
         // Getting PlayerPos
         Vector2 playerPos = grapplingHook.transform.position;
@@ -76,5 +76,30 @@ public class GrappleInputHandler
             // Update the grapple indicator position
             grappleIndicator.UpdateGrappleIndicator(playerPos);
         }
+    }
+
+    public void CheckPlayerInputMethode()
+    {
+        // Check if the player is using a controller
+        if (playerInput.currentControlScheme == "Gamepad")
+        {
+            isUsingController = true;
+        }
+        else
+        {
+            isUsingController = false;
+        }
+    }
+
+    public void LoadActions()
+    {
+        grappleAction = playerInput.actions["Grappling"];
+        aimAction = playerInput.actions["Aiming"];
+    }
+
+    public void UnloadActions()
+    {
+        grappleAction.Disable();
+        aimAction.Disable();
     }
 }

--- a/Projektarbeit III/Assets/Scripts/Player/PlayerController/GrapplingHook.cs
+++ b/Projektarbeit III/Assets/Scripts/Player/PlayerController/GrapplingHook.cs
@@ -20,9 +20,6 @@ public class GrapplingHook : MonoBehaviour
     public Controller controller;           // Reference to the player's state manager
     public LineRenderer lineRenderer;       // Visual representation of the rope
     public float cooldownTimer;             // Timer to track cooldown
-    public InputAction grappleAction;       // Grappling input action
-    public InputAction aimAction;           // Aim input action for controller
-    public bool isUsingController;          // Whether the player is using a controller
     public Vector2 lastControllerDirection; // Last direction from the controller
     public Enemy enemy;                     // Reference to the enemy
     public float toleranceRadius;           // Tolerance for the grapple distance
@@ -46,12 +43,10 @@ public class GrapplingHook : MonoBehaviour
         // Get values from MovementEditor
         GrappleValues.InitializeGrappleValues(this, controller);
 
-        grappleChecks = new GrappleChecks(this, controller, rb, enemy);
+        grappleChecks = new GrappleChecks(this, null, controller, rb, enemy);
         grappleIndicator = new GrappleIndicator(this, grappleChecks, controller, grappleRange, indicatorPuffer, indicatorSize, indicatorSegments);
         grappleInputHandler = new GrappleInputHandler(this, grappleIndicator, controller, grappleRange, lastControllerDirection);
-        grappleAction = grappleInputHandler.grappleAction;
-        aimAction = grappleInputHandler.aimAction;
-        isUsingController = grappleInputHandler.isUsingController;
+        grappleChecks.SetDependencies(grappleInputHandler);
     }
 
     void Update()
@@ -223,8 +218,6 @@ public class GrapplingHook : MonoBehaviour
 
     private void OnDestroy()
     {
-        // Unregister input callbacks
-        grappleAction.Disable();
-        aimAction.Disable();
+        grappleInputHandler.UnloadActions();
     }
 }

--- a/Projektarbeit III/Assets/Scripts/Player/PlayerController/WallJumpingState.cs
+++ b/Projektarbeit III/Assets/Scripts/Player/PlayerController/WallJumpingState.cs
@@ -32,7 +32,7 @@ public class WallJumpingState : Interface.IState
 
     public void OnEnter()
     {
-        Debug.Log("Entered Wall Jumping State");
+        //Debug.Log("Entered Wall Jumping State");
 
         // Determine which wall the player is jumping from
         jumpingFromLeftWall = controller.IsTouchingLeftWall();
@@ -58,6 +58,6 @@ public class WallJumpingState : Interface.IState
 
     public void OnExit()
     {
-        Debug.Log("Exiting Wall Jumping State");
+        //Debug.Log("Exiting Wall Jumping State");
     }
 }


### PR DESCRIPTION
Bug: Grapple Indicator followed only the mouse, even if the player was using the controller 

For this all Keyboard/Controller checks got moved and defined in GrappleInputHandler and there called 
Created Function for better Loading and Unloading of Action Maps 
Removed unnecessary Debug in WallJump